### PR TITLE
Update how vehicle_types is set

### DIFF
--- a/fake/main.py
+++ b/fake/main.py
@@ -88,9 +88,8 @@ def setup_cli():
     parser.add_argument(
         "--propulsion_types",
         type=str,
-        nargs="+",
-        default=[], # to be filled in below if not specified by user
-        metavar="PROPULSION_TYPE",
+        action="append",
+        metavar="PROPULSION_TYPES",
         help="A list of propulsion_types to use for the generated data, e.g. '{}'".format(" ".join(schema.propulsion_types))
     )
     parser.add_argument(
@@ -121,9 +120,8 @@ def setup_cli():
     parser.add_argument(
         "--vehicle_types",
         type=str,
-        nargs="+",
-        default=[], # to be filled in below if not specified by user
-        metavar="VEHICLE_TYPE",
+        action="append",
+        metavar="VEHICLE_TYPES",
         help="A list of vehicle_types to use for the generated data, e.g. '{}'".format(" ".join(schema.vehicle_types))
     )
     parser.add_argument(


### PR DESCRIPTION
The original way to set `vehicle_types` and `propulsion_types` resulted in `"[bicycle,scooter"]` as the output when the script in invoked using the flag as follows: `--vehicle_types=["scooter", "bicycle"]`

According to the [Example](https://docs.python.org/3/library/argparse.html#example) in argparse docs, we should be able to invoke the script using the flag in the following format: `--vehicle_types 'scooter' 'bicycle'` and have the output be: `['scooter', 'bicycle']` but that was not the case. 

I decided to use a different option for parsing arguments as a list and use the `append` action. This means that when multiple options for vehicle_types or propulsion_types is desired, the script would be invoked with the flags as follows: `--vehicle_types='scooter' --vehicle_types='bicycle'`